### PR TITLE
add milliseconds to timestamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ MoveApps
 Github repository: *github.com/movestore/rds2csv*
 
 ## Description
-Movement data (in R-format rds) is transformed into a csv-data.frame that is returned as artefakt and can be downloaded. The original data set is also passed on as output to a possible next App. 
+Movement data are transformed into a table in csv format and provided as an artefact for download. The original moveStack is also passed on as output for use by a subsequent App. 
 
 ## Documentation
-The input Movement data set is transformed into a table (data frame) with a row for each location and columns indicating the timestamp, individual, location coordiantes (longitude, latitude) and other properties of the location. For better readability, only properties (columns) with (non-NA) information in at least one row are retained. This table is returned as an artefact named `data.csv`.
+The input Movement dataset (a moveStack object in R's rds format) is transformed into a table (data frame) with a row for each location and columns indicating the timestamp, individual, location coordinates (longitude, latitude) and other properties of each event record. For better readability, only properties (columns) with (non-NA) information in at least one row are retained. This table is returned as an artefact named `data.csv`.
 
 ### Input data
 moveStack in Movebank format

--- a/RFunction.R
+++ b/RFunction.R
@@ -12,6 +12,7 @@ rFunction <- function(data)
   infos.pr <-c("trackId","timestamp","location.long","location.lat")
   infos.pr.ix <- which(names(data.csv.nona) %in% c("trackId","timestamp","location.long","location.lat"))
   data.csv.nona.pr <- data.frame(data.csv.nona[,infos.pr],data.csv.nona[,-infos.pr.ix])
+  data.csv.nona.pr$timestamp <- strftime(data.csv.nona.pr$timestamp, tz='UTC', usetz=F, format = "%Y-%m-%d %H:%M:%OS3")
     
   write.csv(data.csv.nona.pr, file = paste0(Sys.getenv(x = "APP_ARTIFACTS_DIR", "/tmp/"),"data.csv"),row.names=FALSE)
   #write.csv(data.csv.nona.pr, file = "data.csv",row.names=FALSE)


### PR DESCRIPTION
I don't have a MoveApps test environment to make sure this works, but used the code from the RFunction locally and confirmed the change fixes the problem using my MoveApps .rds output. The data I am using do not have millisecond precision, but I need it included so that the data can be read into other Movebank-compatible programs that expect it. 

I don't know how the moveStack and Write CSV work for datasets containing millisecond values, so can you confirm that this information is not lost? [Here is a study for testing.](https://github.com/movestore/Movebank_Example_Datasets#working-with-milliseconds)